### PR TITLE
fix python_requires= to allow installation under py3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     keywords='cryptography noiseprotocol noise security',
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
     install_requires=['cryptography==2.1.4'],
-    python_requires='~=3.5,~=3.6',
+    python_requires='~=3.5', # we like 3.5, 3.6, and beyond, but not 4.0
 )


### PR DESCRIPTION
Thanks for implementing Noise! I'm looking forward to using it in https://github.com/warner/magic-wormhole . I had a problem testing under python3.5, though.

According to PEP440, a comma in a version specifier behaves as a logical AND,
so the previous `"~=3.5,~=3.6"` is equivalent to just `"~=3.6"`, which excludes
python3.5.

This patch replaces it with `"~=3.5"`, which is equivalent to `">=3.5, ==3.*"`,
so it includes 3.5, 3.6, 3.7, and beyond (but not 4.0).

The error symptom was that `pip install noiseprotocol` in a python3.5 virtualenv would fail, complaining that there was no compatible distribution:

```
warner@xoanon:/tmp$ virtualenv -p python3.5 ve35
Running virtualenv with interpreter /usr/bin/python3.5
Using base prefix '/usr'
New python executable in /tmp/ve35/bin/python3.5
Also creating executable in /tmp/ve35/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
warner@xoanon:/tmp$ source ve35/bin/activate
(ve35) warner@xoanon:/tmp$ pip list
Package       Version
------------- -------
pip           9.0.1
pkg-resources 0.0.0
setuptools    38.5.2
wheel         0.30.0
(ve35) warner@xoanon:/tmp$ pip install noiseprotocol
Collecting noiseprotocol
  Could not find a version that satisfies the requirement noiseprotocol (from versions: )
No matching distribution found for noiseprotocol
(ve35) warner@xoanon:/tmp$
```