### PR TITLE
Update scapy

### DIFF
--- a/examples/wireguard/README.md
+++ b/examples/wireguard/README.md
@@ -1,5 +1,5 @@
 This example shows interoperability with Wireguard. 
 It connects to Wireguard service, does a handshake, sends and receives a ping.
 
-Run with noiseprotocol and scapy-python3 installed in your environment (python main.py) 
-or directly from here (PYTHONPATH=../../ python main.py) (you still need scapy-python3)
+Run with noiseprotocol and scapy installed in your environment (python main.py) 
+or directly from here (PYTHONPATH=../../ python main.py) (you still need scapy)

--- a/examples/wireguard/requirements.txt
+++ b/examples/wireguard/requirements.txt
@@ -1,2 +1,2 @@
 noiseprotocol
-scapy-python3
+scapy>=2.4.0


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3