### PR TITLE
fix use of x25519 private keys

### DIFF
--- a/noise/functions.py
+++ b/noise/functions.py
@@ -162,7 +162,7 @@ class KeyPair25519(_KeyPair):
     def from_private_bytes(cls, private_bytes):
         if len(private_bytes) != 32:
             raise NoiseValueError('Invalid length of private_bytes! Should be 32')
-        private = x25519.X25519PrivateKey._from_private_bytes(private_bytes)
+        private = x25519.X25519PrivateKey.from_private_bytes(private_bytes)
         public = private.public_key()
         return cls(private=private, public=public, public_bytes=public.public_bytes())
 


### PR DESCRIPTION
This underscore is a typo and stops x25519 private keys from being used.