### PR TITLE
fix deprecation warning in call to public_bytes()

### DIFF
--- a/noise/backends/default/diffie_hellmans.py
+++ b/noise/backends/default/diffie_hellmans.py
@@ -1,4 +1,5 @@
 from cryptography.hazmat.primitives.asymmetric import x25519, x448
+from cryptography.hazmat.primitives import serialization
 
 from noise.backends.default.keypairs import KeyPair25519, KeyPair448
 from noise.exceptions import NoiseValueError
@@ -17,7 +18,9 @@ class ED25519(DH):
     def generate_keypair(self) -> 'KeyPair':
         private_key = x25519.X25519PrivateKey.generate()
         public_key = private_key.public_key()
-        return KeyPair25519(private_key, public_key, public_key.public_bytes())
+        return KeyPair25519(private_key, public_key,
+                            public_key.public_bytes(serialization.Encoding.Raw,
+                                                    serialization.PublicFormat.Raw))
 
     def dh(self, private_key, public_key) -> bytes:
         if not isinstance(private_key, x25519.X25519PrivateKey) or not isinstance(public_key, x25519.X25519PublicKey):
@@ -37,7 +40,9 @@ class ED448(DH):
     def generate_keypair(self) -> 'KeyPair':
         private_key = x448.X448PrivateKey.generate()
         public_key = private_key.public_key()
-        return KeyPair448(private_key, public_key, public_key.public_bytes())
+        return KeyPair448(private_key, public_key,
+                          public_key.public_bytes(serialization.Encoding.Raw,
+                                                  serialization.PublicFormat.Raw))
 
     def dh(self, private_key, public_key) -> bytes:
         if not isinstance(private_key, x448.X448PrivateKey) or not isinstance(public_key, x448.X448PublicKey):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,34 @@
+from noise.connection import NoiseConnection
+
+class TestConnection(object):
+    def do_test_connection(self, name):
+        key = b"\x00" * 32
+        left = NoiseConnection.from_name(name)
+        left.set_psks(key)
+        left.set_as_initiator()
+        left.start_handshake()
+
+        right = NoiseConnection.from_name(name)
+        right.set_psks(key)
+        right.set_as_responder()
+        right.start_handshake()
+
+        h = left.write_message()
+        _ = right.read_message(h)
+        h2 = right.write_message()
+        left.read_message(h2)
+
+        assert left.handshake_finished
+        assert right.handshake_finished
+
+        enc = left.encrypt(b"hello")
+        dec = right.decrypt(enc)
+        assert dec == b"hello"
+
+    def test_25519(self):
+        name = b"Noise_NNpsk0_25519_ChaChaPoly_BLAKE2s"
+        self.do_test_connection(name)
+
+    def test_448(self):
+        name = b"Noise_NNpsk0_448_ChaChaPoly_BLAKE2s"
+        self.do_test_connection(name)


### PR DESCRIPTION
It looks like the calls to KeyPair25519 and KeyPair448 weren't being
exercised by the tests, so the 'cryptography' deprecation warnings that they
provoked weren't visible in the test run.

KeyPair448 requires the extra encoding/format parameters, so any uses of
Noise that has "448" in the name would probably have failed. KeyPair25519 was
lenient (since the original release didn't require those parameters), but has
started emitting warnings when they're omitted, and will probably start
throwing errors in the next release. So this patch is needed to fix 448 now,
and 25519 later.

refs #32