### PR TITLE
add a test and fix 448...

### DIFF
--- a/noise/backends/default/diffie_hellmans.py
+++ b/noise/backends/default/diffie_hellmans.py
@@ -1,4 +1,5 @@
 from cryptography.hazmat.primitives.asymmetric import x25519, x448
+from cryptography.hazmat.primitives import serialization
 
 from noise.backends.default.keypairs import KeyPair25519, KeyPair448
 from noise.exceptions import NoiseValueError
@@ -37,7 +38,8 @@ class ED448(DH):
     def generate_keypair(self) -> 'KeyPair':
         private_key = x448.X448PrivateKey.generate()
         public_key = private_key.public_key()
-        return KeyPair448(private_key, public_key, public_key.public_bytes())
+        return KeyPair448(private_key, public_key, public_key.public_bytes(encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw))
 
     def dh(self, private_key, public_key) -> bytes:
         if not isinstance(private_key, x448.X448PrivateKey) or not isinstance(public_key, x448.X448PublicKey):


### PR DESCRIPTION
If you use 448 in a real environment (where you don't statically set the ephemeral keys like the test vectors do), you'll run into an exception like the following (this is generated from the tests w/o the fix to diffie_hellmans.py):
```
___________________________________________________ TestVectors.test_vector[Noise_XK_448_ChaChaPoly_SHA512] ___________________________________________________

self = <tests.test_vectors.TestVectors object at 0x109685e10>
vector = {'handshake_hash': b'\x8d\xb8\xe04\xb8TE\x0fkC\xa8\xe8K$\x8e#\xd5\xbcL\x96\xb4\xaf\x92!\x99\xf9K\x82\x82z\x95\x01Q\xc1...xac\xa1\xb7\x0fA{\xfc8\x1b(\xb2\x1bX5\xd8L\xf7\xa6\xdaj\xbb\xa1\x9e;\xa7\xd4k%4\x12\xb7Fe\xd4b{e\xfc\xef?)\xc9]>', ...}

    def test_vector(self, vector):
        if b'_XK_448_' in vector['protocol_name']:
>           self.e2etest(vector)

tests/test_vectors.py:118: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_vectors.py:97: in e2etest
    r.read_message(s.write_message())
noise/connection.py:110: in write_message
    result = self.noise_protocol.handshake_state.write_message(payload, buffer)
noise/state.py:306: in write_message
    self.e = self.noise_protocol.dh_fn.generate_keypair() if isinstance(self.e, Empty) else self.e
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <noise.backends.default.diffie_hellmans.ED448 object at 0x109685f28>

    def generate_keypair(self) -> 'KeyPair':
        private_key = x448.X448PrivateKey.generate()
        public_key = private_key.public_key()
>       return KeyPair448(private_key, public_key, public_key.public_bytes())
E       TypeError: public_bytes() missing 2 required positional arguments: 'encoding' and 'format'

noise/backends/default/diffie_hellmans.py:41: TypeError
```