### PR TITLE
Provide the ability to get remote static public key

### DIFF
--- a/noise/connection.py
+++ b/noise/connection.py
@@ -92,6 +92,9 @@ class NoiseConnection(object):
             self.noise_protocol.keypairs[_keypairs[keypair]] = \
                 self.noise_protocol.dh_fn.klass.from_public_bytes(fd.read())
 
+    def get_public_bytes(self, keypair: Keypair) -> bytes:
+        return self.noise_protocol.keypairs[_keypairs[keypair]].public_bytes
+
     def start_handshake(self):
         self.noise_protocol.validate()
         self.noise_protocol.initialise_handshake_state()

--- a/noise/connection.py
+++ b/noise/connection.py
@@ -5,7 +5,7 @@ from cryptography.exceptions import InvalidTag
 
 from noise.backends.default import noise_backend
 from noise.constants import MAX_MESSAGE_LEN
-from noise.exceptions import NoisePSKError, NoiseValueError, NoiseHandshakeError, NoiseInvalidMessage
+from noise.exceptions import NoisePSKError, NoiseValueError, NoiseHandshakeError, NoiseInvalidMessage, NoiseGetPublicKeyError
 from .noise_protocol import NoiseProtocol
 
 
@@ -93,6 +93,9 @@ class NoiseConnection(object):
                 self.noise_protocol.dh_fn.klass.from_public_bytes(fd.read())
 
     def get_public_bytes(self, keypair: Keypair) -> bytes:
+        the_key = self.noise_protocol.keypairs[_keypairs[keypair]]
+        if the_key is None:
+            raise NoiseGetPublicKeyError('The required key is not available or not ready yet')
         return self.noise_protocol.keypairs[_keypairs[keypair]].public_bytes
 
     def start_handshake(self):

--- a/noise/exceptions.py
+++ b/noise/exceptions.py
@@ -24,3 +24,6 @@ class NoiseMaxNonceError(Exception):
 
 class NoiseValidationError(Exception):
     pass
+
+class NoiseGetPublicKeyError(Exception):
+    pass

--- a/noise/state.py
+++ b/noise/state.py
@@ -304,6 +304,8 @@ class HandshakeState(object):
             if token == TOKEN_E:
                 # Sets e = GENERATE_KEYPAIR(). Appends e.public_key to the buffer. Calls MixHash(e.public_key)
                 self.e = self.noise_protocol.dh_fn.generate_keypair() if isinstance(self.e, Empty) else self.e
+                self.noise_protocol.keypairs['e'] = self.e
+
                 message_buffer += self.e.public_bytes
                 self.symmetric_state.mix_hash(self.e.public_bytes)
                 if self.noise_protocol.is_psk_handshake:
@@ -364,6 +366,8 @@ class HandshakeState(object):
             if token == TOKEN_E:
                 # Sets re to the next DHLEN bytes from the message. Calls MixHash(re.public_key).
                 self.re = self.noise_protocol.keypair_class.from_public_bytes(bytes(message[:dhlen]))
+                self.noise_protocol.keypairs['re'] = self.re
+
                 message = message[dhlen:]
                 self.symmetric_state.mix_hash(self.re.public_bytes)
                 if self.noise_protocol.is_psk_handshake:
@@ -381,6 +385,7 @@ class HandshakeState(object):
                 self.rs = self.noise_protocol.keypair_class.from_public_bytes(
                     self.symmetric_state.decrypt_and_hash(temp)
                 )
+                self.noise_protocol.keypairs['rs'] = self.rs
 
             elif token == TOKEN_EE:
                 # Calls MixKey(DH(e, re)).

--- a/tests/test_get_public.py
+++ b/tests/test_get_public.py
@@ -3,8 +3,11 @@
 import base64
 import typing
 
+import pytest
+
 from noise.connection import NoiseConnection
 from noise.connection import Keypair
+from noise.exceptions import NoiseGetPublicKeyError
 
 
 _Keys = typing.NamedTuple(
@@ -29,10 +32,18 @@ def _do_test_for(key_type: str, keys: _Keys):
 
     initiator.start_handshake()
     responder.start_handshake()
-
     message = b'public-key-test'
+
     assert message == responder.read_message(initiator.write_message(message))
+    with pytest.raises(NoiseGetPublicKeyError):
+        initiator.get_public_bytes(Keypair.REMOTE_STATIC)
+    with pytest.raises(NoiseGetPublicKeyError):
+        responder.get_public_bytes(Keypair.REMOTE_STATIC)
+
     assert message == initiator.read_message(responder.write_message(message))
+    with pytest.raises(NoiseGetPublicKeyError):
+        responder.get_public_bytes(Keypair.REMOTE_STATIC)
+
     assert message == responder.read_message(initiator.write_message(message))
 
     # Test ability to get remote static public key,

--- a/tests/test_get_public.py
+++ b/tests/test_get_public.py
@@ -1,0 +1,71 @@
+"""Test get public feature for NoiseConnection class."""
+
+import base64
+import typing
+
+from noise.connection import NoiseConnection
+from noise.connection import Keypair
+
+
+_Keys = typing.NamedTuple(
+    'Keys',
+    [
+        ('initiator_private', bytes),
+        ('initiator_public', bytes),
+        ('responder_private', bytes),
+        ('responder_public', bytes),
+    ]
+)
+
+def _do_test_for(key_type: str, keys: _Keys):
+    noise_name = 'Noise_XX_{}_ChaChaPoly_SHA256'.format(key_type).encode()
+    initiator = NoiseConnection.from_name(noise_name)
+    responder = NoiseConnection.from_name(noise_name)
+    initiator.set_as_initiator()
+    responder.set_as_responder()
+
+    initiator.set_keypair_from_private_bytes(Keypair.STATIC, keys.initiator_private)
+    responder.set_keypair_from_private_bytes(Keypair.STATIC, keys.responder_private)
+
+    initiator.start_handshake()
+    responder.start_handshake()
+
+    message = b'public-key-test'
+    assert message == responder.read_message(initiator.write_message(message))
+    assert message == initiator.read_message(responder.write_message(message))
+    assert message == responder.read_message(initiator.write_message(message))
+
+    # Test ability to get remote static public key,
+    # which is essential for application layer to validate peer identity
+    assert keys.responder_public == initiator.get_public_bytes(Keypair.REMOTE_STATIC)
+    assert keys.initiator_public == responder.get_public_bytes(Keypair.REMOTE_STATIC)
+
+    # Other tests
+    assert initiator.get_public_bytes(Keypair.REMOTE_EPHEMERAL) == responder.get_public_bytes(Keypair.EPHEMERAL)
+    assert responder.get_public_bytes(Keypair.REMOTE_EPHEMERAL) == initiator.get_public_bytes(Keypair.EPHEMERAL)
+
+
+def test_x25519_get_public_key():
+    """Test get public key for x25519."""
+    _do_test_for(
+        '25519',
+        _Keys(
+            base64.b64decode(b'+BWGKo59m/EjzLAIDb2WlIMKRwilG8G70rKiBvaDgm0='),
+            base64.b64decode(b'7zOPAAeyz9CRHHdi0d5ntdk2TwYKiHYmx7tX34rJXgA='),
+            base64.b64decode(b'ODyYIHfQ2W47bVek/B8NS06n2bXex12omxqb5C7bu24='),
+            base64.b64decode(b'xqkyauPBj6Ogcn6WT5p35pt0NKSByuF4RBk/JR+rHys='),
+        ),
+    )
+
+
+def test_x448_get_public_key():
+    """Test get public key for 448."""
+    _do_test_for(
+        '448',
+        _Keys(
+            base64.b64decode(b'nJUX8VL2G7yZsuNHnb/kEA1HT+sdexEQyDg7M6dQj3lkzrE8IPpAkwy0N9ScWGYc1NY9ODQXzNQ='),
+            base64.b64decode(b'6jmDfnjy428DZWP8G3wOrFOim0CJFAylGjxquGWXcN0pBL1srYMz9ftHkSK4zXxpxeCa5qZBc5Y='),
+            base64.b64decode(b'FH2DokPJMRUYyOwgo9IwAMd5txaUU4yr8gxzjEzSZrpeZ1vsdtEELDR6ylN99wRvfyjceK7jZfk='),
+            base64.b64decode(b'G4w7WRu5KnEC1W8iH90/priXAe/r5OaU5l2/5zWgJAyDMtXGf6zfAs23khPI5uxV/hP1zM3ItwY='),
+        ),
+    )


### PR DESCRIPTION
It's the application's responsibility to determine whether the remote party's static public key is acceptable, as the security consideration section stated in The Noise Protocol Framework. However, the current implementation does not provide the opportunity for application to examine the remote party's static public key. 

Once the handshake process is done, the `HandshakeState` object is deleted, and this is also the recommended behavior. Thus, in this PR, I try to reuse the `keypairs` field in `NoiseProtocol` object to record the keypairs which will be encountered during the handshake process, and provide a `get_public_bytes` interface to retrieve these keys. 

The test for this new API is also provided in this PR.