### PR TITLE
Noise limits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+Upcoming Version
+~~~~~~~~~~~~~~~~
+
+* Fix message limits for plaintext (#44, from meejah)
+
+
 .. _v0-3-1:
 
 0.3.1 - 2020-03-03

--- a/noise/connection.py
+++ b/noise/connection.py
@@ -4,7 +4,7 @@ from typing import Union, List
 from cryptography.exceptions import InvalidTag
 
 from noise.backends.default import noise_backend
-from noise.constants import MAX_MESSAGE_LEN
+from noise.constants import MAX_MESSAGE_LEN, MAX_PLAINTEXT_LEN
 from noise.exceptions import NoisePSKError, NoiseValueError, NoiseHandshakeError, NoiseInvalidMessage
 from .noise_protocol import NoiseProtocol
 
@@ -130,7 +130,7 @@ class NoiseConnection(object):
     def encrypt(self, data: bytes) -> bytes:
         if not self.handshake_finished:
             raise NoiseHandshakeError('Handshake not finished yet!')
-        if not isinstance(data, bytes) or len(data) > MAX_MESSAGE_LEN:
+        if not isinstance(data, bytes) or len(data) > MAX_PLAINTEXT_LEN:
             raise NoiseInvalidMessage('Data must be bytes and less or equal {} bytes in length'.format(MAX_MESSAGE_LEN))
         return self.noise_protocol.cipher_state_encrypt.encrypt_with_ad(None, data)
 

--- a/noise/constants.py
+++ b/noise/constants.py
@@ -16,5 +16,7 @@ TOKEN_PSK = 'psk'
 MAX_PROTOCOL_NAME_LEN = 255
 
 MAX_MESSAGE_LEN = 65535
+# encryption adds 16 bytes of authentication data
+MAX_PLAINTEXT_LEN = 65535 - 16
 
 MAX_NONCE = 2 ** 64 - 1

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,6 @@
 from noise.connection import NoiseConnection
+import pytest
+
 
 class TestConnection(object):
     def do_test_connection(self, name):
@@ -32,3 +34,59 @@ class TestConnection(object):
     def test_448(self):
         name = b"Noise_NNpsk0_448_ChaChaPoly_BLAKE2s"
         self.do_test_connection(name)
+
+
+@pytest.fixture
+def protocol_name():
+    return b"Noise_NNpsk0_25519_ChaChaPoly_BLAKE2s"
+
+
+@pytest.fixture
+def connection(protocol_name):
+    key = b"\x00" * 32
+    left = NoiseConnection.from_name(protocol_name)
+    left.set_psks(key)
+    left.set_as_initiator()
+    left.start_handshake()
+
+    right = NoiseConnection.from_name(protocol_name)
+    right.set_psks(key)
+    right.set_as_responder()
+    right.start_handshake()
+
+    h = left.write_message()
+    _ = right.read_message(h)
+    h2 = right.write_message()
+    left.read_message(h2)
+
+    assert left.handshake_finished
+    assert right.handshake_finished
+
+    return left, right
+
+
+@pytest.mark.parametrize(
+    "input_size,success",
+    [(x, False) for x in range(65520, 65555, 1)] +  # all too big
+    [(x, True) for x in range(0, 65000, 100)] +  # all fine, don't test every size
+    [(x, True) for x in range(65256, 65519, 1)]  # also fine
+)
+def test_limits(connection, success, input_size):
+    """
+    test around the limits of message sizes to ensure we get proper
+    errors
+    """
+    left, right = connection
+    plaintext = b"\xff" * input_size
+
+    if not success:
+        try:
+            left.encrypt(plaintext)
+        except Exception as e:
+            return
+        assert False, "expected an error on input size {}".format(input_size)
+
+    else:
+        enc = left.encrypt(plaintext)
+        dec = right.decrypt(enc)
+        assert dec == plaintext, "encryption + decryption doesn't match original"


### PR DESCRIPTION
Fixes #44 

The maximum plaintext that can be encrypted is actually 16 bytes fewer than the maximum (encrypted) message size.